### PR TITLE
Expand ~ in CIRRUS_VERSIONS_PATH

### DIFF
--- a/src/deploy/scripts/runcirrus.py
+++ b/src/deploy/scripts/runcirrus.py
@@ -170,7 +170,7 @@ def get_versions_path() -> Path:
 
     """
     if (path := os.environ.get("CIRRUS_VERSIONS_PATH")) is not None:
-        return Path(path)
+        return Path(path).expanduser()
 
     search_path = Path(os.path.dirname(__file__)).resolve()
 


### PR DESCRIPTION
Path's expanduser() function does exactly this. Otherwise `~` is treated as its own filename.

Tested by:
```py
>>> from pathlib import Path
>>> Path("~/cirrus").resolve()
PosixPath('/var/home/zohar/Develop/Equinor/CCS/cirrus-deploy/~/cirrus')
>>> Path("~/cirrus").expanduser()
PosixPath('/var/home/zohar/cirrus')
```

Resolves: #20 