### PR TITLE
More expanduser

### DIFF
--- a/src/deploy/__main__.py
+++ b/src/deploy/__main__.py
@@ -33,13 +33,12 @@ Args = _Args()
 @click.option(
     "--prefix",
     "-p",
-    is_flag=True,
     help="Installation location",
     default="~/cirrus",
 )
 def cli(config_dir: str, prefix: str) -> None:
-    Args.config_dir = Path(config_dir).resolve()
-    Args.prefix = Path(prefix).resolve()
+    Args.config_dir = Path(config_dir).expanduser().resolve()
+    Args.prefix = Path(prefix).expanduser().resolve()
 
 
 @cli.command(help="Check locations")
@@ -72,7 +71,7 @@ def build(force: bool, extra_scripts: str) -> None:
     tmp_path = Path("tmp").resolve()
     tmp_path.mkdir(parents=True, exist_ok=True)
     extra_scripts_path = (
-        Path(extra_scripts).resolve() if len(extra_scripts) > 0 else None
+        Path(extra_scripts).expanduser().resolve() if len(extra_scripts) > 0 else None
     )
     configpath = Path.cwd()
     config = load_config(configpath)

--- a/src/deploy/scripts/runcirrus.py
+++ b/src/deploy/scripts/runcirrus.py
@@ -378,7 +378,7 @@ def main() -> None:
             argv.append(arg)
 
     args = parse_args(argv)
-    input_file = Path(args.input).resolve()
+    input_file = Path(args.input).expanduser().resolve()
     if not input_file.exists():
         sys.exit(f"Cirrus input file '{input_file}' does not exit!")
 
@@ -416,9 +416,9 @@ def main() -> None:
     num_tasks = args.num_machines * args.num_tasks_per_machine
 
     if args.output_directory:
-        outdir = Path(args.output_directory)
+        outdir = Path(args.output_directory).expanduser()
     else:
-        outdir = Path(args.input).parent
+        outdir = Path(args.input).expanduser().parent
 
     script = SCRIPT.format(
         root=rootdir,


### PR DESCRIPTION
Eg, `Path("~/cirrus").resolve()` will expand to `Path.cwd() / "~/cirrus"`, which is not expected. This `.expanduser()` to a few `Path`s where the user may reasonably expect `~` to work as replacement for their home directory.