### PR TITLE
Have links occur on build

### DIFF
--- a/src/deploy/__main__.py
+++ b/src/deploy/__main__.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 
 from deploy.build import Build
 from deploy.config import load_config
-from deploy.links import make_links
 from deploy.check import do_check
 from deploy.package_list import PackageList
 from deploy.sync import do_sync
@@ -90,13 +89,6 @@ def build(force: bool) -> None:
         prefix=Args.prefix,
     )
     builder.build()
-
-
-@cli.command(help="Generate symlinks from ./symlinks.json")
-def links() -> None:
-    configpath = Path.cwd()
-    config = load_config(configpath)
-    make_links(config.links, prefix=Args.prefix)
 
 
 @cli.command(help="Run tests in ./deploy_tests using pytest")

--- a/src/deploy/build.py
+++ b/src/deploy/build.py
@@ -148,6 +148,7 @@ class Build:
             prefix=prefix,
             check_existence=False,
         )
+        self.env_links: dict[str, dict[str, str]] = config.links
 
     @property
     def packages(self) -> dict[str, Package]:
@@ -169,7 +170,12 @@ class Build:
             if path is None:
                 continue
             self._build_env_for_package(path, pkg)
-            self._create_default_symlinks(self.package_list.prefix / dest, path)
+
+            default_links: dict[str, str] = {"latest": "^", "stable": "latest"}
+            make_links(
+                links={**default_links, **self.env_links.get(dest, {})},
+                prefix=self.package_list.prefix / dest,
+            )
             self._create_wrapper_script(dest, pkg, entrypoint)
 
     def _build_env_for_package(self, base: Path, finalpkg: Package) -> None:
@@ -233,8 +239,3 @@ exec "$ENTRY_POINT" "${{@:2}}"
 
         wrapper_script.write_text(script_content)
         wrapper_script.chmod(0o755)
-
-    def _create_default_symlinks(self, base: Path, target: Path) -> None:
-        rel_base = base.relative_to(self.package_list.prefix)
-        default_links = {str(rel_base): {"latest": "^", "stable": "latest"}}
-        make_links(default_links, prefix=self.package_list.prefix, force=False)

--- a/src/deploy/links.py
+++ b/src/deploy/links.py
@@ -45,22 +45,17 @@ def validate(base: Path) -> None:
 
 
 def make_links(
-    links: dict[str, dict[str, str]],
+    links: dict[str, str],
     prefix: Path,
-    force: bool = True,
 ) -> None:
-    for subdir, link_specs in links.items():
-        for source, target in link_specs.items():
-            path = prefix / subdir / source
+    for source, target in links.items():
+        path = prefix / source
 
-            if not force and path.exists():
-                continue
+        if target == "^":
+            target = get_latest(prefix)
 
-            if target == "^":
-                target = get_latest(prefix / subdir)
+        path.unlink(missing_ok=True)
+        path.symlink_to(target)
+        print(f"Created symlink: {path} -> {target}")
 
-            path.unlink(missing_ok=True)
-            path.symlink_to(target)
-            print(f"Created symlink: {path} -> {target}")
-
-        validate(prefix / subdir)
+    validate(prefix)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -176,7 +176,7 @@ def test_clean_package_cache_on_rebuild(
         assert "clean" in git_commands
 
 
-def test_default_symlinks_created_on_build(tmp_path, base_config):
+def test_not_overwrite_user_set_links_with_default(tmp_path, base_config):
     base_config["builds"].append(
         {"name": "test", "version": "1.0.0", "build": "mkdir -p $out/bin\n"}
     )
@@ -189,8 +189,21 @@ def test_default_symlinks_created_on_build(tmp_path, base_config):
     stable_link = tmp_path / "versions" / "stable"
     latest_link = tmp_path / "versions" / "latest"
 
-    assert stable_link.is_symlink()
-    assert latest_link.is_symlink()
     assert str(stable_link.readlink()) == "latest"
     assert str(latest_link.readlink()) == "1.0.0-1"
     assert stable_link.resolve() == latest_link.resolve()
+
+    # Now we create a new build with a new version, but we set the stable link to point to the old version
+    base_config["builds"] = [
+        {"name": "test", "version": "1.0.1", "build": "mkdir -p $out/bin\n"}
+    ]
+    base_config["links"] = {"versions": {"stable": "1.0.0"}}
+
+    config = Config.model_validate(base_config)
+    builder = Build(tmp_path, config, extra_scripts=tmp_path, prefix=tmp_path)
+    builder.build()
+
+    assert stable_link.is_symlink()
+    assert latest_link.is_symlink()
+    assert str(stable_link.readlink()) == "1.0.0"
+    assert str(latest_link.readlink()) == "1.0.1-1"

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -24,13 +24,13 @@ def _setup_env(tmp_path, base_config):
 
 def test_make_links(tmp_path, base_config):
     _setup_env(tmp_path, base_config)
-    make_links(base_config["links"], prefix=tmp_path)
+    make_links(base_config["links"]["location"], prefix=tmp_path / "location")
     assert (tmp_path / "location/symlink").exists()
 
 
 def test_make_links_fail_missing_target(tmp_path, base_config):
     with pytest.raises(FileNotFoundError, match="No such file or directory: 'target'"):
-        make_links(base_config["links"], prefix=tmp_path)
+        make_links(base_config["links"]["location"], prefix=tmp_path / "location")
 
 
 def test_make_links_on_new_package_resolves_latest(tmp_path, base_config):
@@ -39,27 +39,14 @@ def test_make_links_on_new_package_resolves_latest(tmp_path, base_config):
     (tmp_path / "location" / "1.0.0").mkdir(parents=True)
     (tmp_path / "location" / "1.0.1").mkdir(parents=True)
 
-    make_links(base_config["links"], prefix=tmp_path)
+    make_links(base_config["links"]["location"], prefix=tmp_path / "location")
     assert os.path.islink(tmp_path / "location/cool")
     assert os.path.realpath(tmp_path / "location/cool") == str(
         (tmp_path / "location" / "1.0.1")
     )
 
     (tmp_path / "location" / "1.0.2").mkdir(parents=True)
-    make_links(base_config["links"], prefix=tmp_path)
+    make_links(base_config["links"]["location"], prefix=tmp_path / "location")
     assert os.path.realpath(tmp_path / "location/cool") == str(
         (tmp_path / "location" / "1.0.2")
-    )
-
-
-def test_some(tmp_path, base_config):
-    base_config["links"] = {"location": {"1.0": "1.0.1"}}
-
-    (tmp_path / "location" / "1.0.0").mkdir(parents=True)
-    (tmp_path / "location" / "1.0.1").mkdir(parents=True)
-
-    make_links(base_config["links"], prefix=tmp_path)
-    assert os.path.islink(tmp_path / "location/1.0")
-    assert os.path.realpath(tmp_path / "location/1.0") == str(
-        (tmp_path / "location" / "1.0.1")
     )

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -6,7 +6,6 @@ import pytest
 
 from deploy.build import Build
 from deploy.config import Config
-from deploy.links import make_links
 from deploy.sync import Sync, do_sync, change_prefix
 
 BUILD_SCRIPT = """\
@@ -94,7 +93,6 @@ def test_successful_sync(tmp_path, base_config):
 
     builder = _deploy_config(base_config, tmp_path)
 
-    make_links(base_config.links, prefix=tmp_path)
     pkg = builder.packages["A"]
     installed_file_path = pkg.out / "bin/a_file"
     assert installed_file_path.exists()


### PR DESCRIPTION
We have modified our setup for entrypoint scripts, which relies on
some symlinks existing. Remove the individual call for making symlink
and rather have them be part of build.
