### PR TITLE
Phast config 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV VIRTUAL_ENV="/tmp/deploy_env"
 WORKDIR /work
 
 COPY ./src ./src
-COPY ./poetry.lock ./poetry.lock
+COPY ./uv.lock ./uv.lock
 COPY ./pyproject.toml ./pyproject.toml
 COPY ./config.yaml ./config.yaml
 # Poetry requires readme to exist
@@ -27,7 +27,7 @@ RUN ssh-keyscan github.com >> /root/.ssh/known_hosts
 RUN chmod 0700 /root/.ssh
 
 RUN pip install --upgrade pip
-RUN pip install poetry
-RUN poetry install
+RUN pip install uv
+RUN uv sync
 
 ENTRYPOINT ["/bin/bash","-c", "source /tmp/deploy_env/bin/activate; bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,28 @@
 # This Dockerfile initiates a working environment that can be used to run deploy script
-# After 
 
-FROM rockylinux:8
+FROM python:3.11-bookworm
 
-RUN dnf -y groupinstall "Development Tools"
-RUN dnf -y install which
-RUN dnf -y install python3.11
-RUN dnf -y install gcc-gfortran
-RUN dnf -y install git
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    cmake \
+    gfortran \
+    git \
+    libhdf5-dev \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN python3.11 -m venv /tmp/deploy_env
+RUN python3 -m venv /tmp/deploy_env
 ENV PATH="/tmp/deploy_env/bin:$PATH"
 ENV VIRTUAL_ENV="/tmp/deploy_env"
+ENV UV_PROJECT_ENVIRONMENT="/tmp/deploy_env"
 
 WORKDIR /work
 
 COPY ./src ./src
 COPY ./uv.lock ./uv.lock
 COPY ./pyproject.toml ./pyproject.toml
-COPY ./config.yaml ./config.yaml
 # Poetry requires readme to exist
 RUN touch ./README.md
 

--- a/examples/full/phast.config.yaml
+++ b/examples/full/phast.config.yaml
@@ -13,9 +13,8 @@ packages:
       git submodule update --init --recursive
       export BOOST_ROOT="$out"
       mkdir build && cd build
-      cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$out" -DCMAKE_OSX_SYSROOT="$(xcrun --show-sdk-path)"
+      cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$out"
       make install
-
 
   - name: phast
     version: 3.8.6
@@ -26,9 +25,11 @@ packages:
       ref: a37cd5f224302fa88a1c903f73d4490b5f4a235c
 
     build: |
-      
+      autoreconf -fi
       ./configure                                  \
-          
+          --with-boost="$boost"                    \
+          CPPFLAGS="-I/usr/include/hdf5/serial"    \
+          LDFLAGS="-L/usr/lib/aarch64-linux-gnu/hdf5/serial"
       make all
       make check
       make install

--- a/examples/full/phast.config.yaml
+++ b/examples/full/phast.config.yaml
@@ -1,0 +1,34 @@
+main-package: phast
+entrypoint: bin/phast
+
+packages:
+  - name: boost
+    version: 1.89.0
+    src:
+      type: git
+      url: https://github.com/boostorg/boost.git
+      ref: 1bed2b0712b2119f20d66c5053def9173c8462a5
+
+    build: |
+      git submodule update --init --recursive
+      export BOOST_ROOT="$out"
+      mkdir build && cd build
+      cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$out" -DCMAKE_OSX_SYSROOT="$(xcrun --show-sdk-path)"
+      make install
+
+
+  - name: phast
+    version: 3.8.6
+    depends: [ boost ]
+    src:
+      type: git
+      url: https://github.com/equinor/phast_usgs
+      ref: a37cd5f224302fa88a1c903f73d4490b5f4a235c
+
+    build: |
+      
+      ./configure                                  \
+          
+      make all
+      make check
+      make install

--- a/src/deploy/package_list.py
+++ b/src/deploy/package_list.py
@@ -17,8 +17,8 @@ class PackageList:
         prefix: Path,
         check_existence: bool = True,
     ) -> None:
-        self.prefix: Path = prefix
-        self.storepath: Path = prefix / ".store"
+        self.prefix: Path = prefix.resolve()
+        self.storepath: Path = self.prefix / ".store"
         self.config: Config = config
         buildmap = {x.name: x for x in config.packages}
 


### PR DESCRIPTION
- Switch base image from rockylinux to python:3.11-bookworm (because some missing build tool stuff in rockylinux)
- Add missing build deps (cmake, autoconf, automake, libhdf5-dev)
- Add phast.config.yaml for building boost + phast