### PR TITLE
Change build id prefix - to +

### DIFF
--- a/src/karsk/builder.py
+++ b/src/karsk/builder.py
@@ -284,7 +284,7 @@ def _build_env_for_package(paths: Paths, env_path: Path, main_package: Package) 
 
 def _get_versions_path(paths: Paths, finalpkg: Package) -> Path | None:
     for i in range(1, 1000):
-        path = paths.versions / f"{finalpkg.config.version}-{i}"
+        path = paths.versions / f"{finalpkg.config.version}+{i}"
         if not path.is_dir():
             return path
 

--- a/src/karsk/commands/sync.py
+++ b/src/karsk/commands/sync.py
@@ -78,7 +78,7 @@ class Sync:
             context="store",
         )
 
-        # 3. Sync environments (eg. versions/1.0.2-2)
+        # 3. Sync environments (eg. versions/1.0.2+2)
         await self._rsync(
             area,
             self._env_paths,

--- a/src/karsk/links.py
+++ b/src/karsk/links.py
@@ -7,6 +7,17 @@ from pathlib import Path
 from semver import Version
 
 
+def _version_key(version: Version) -> tuple[int, int, int, str, int]:
+    """Sortable key that includes build metadata, which semver ignores by default."""
+    return (
+        version.major,
+        version.minor,
+        version.patch,
+        version.prerelease or "",
+        int(version.build) if version.build else 0,
+    )
+
+
 def get_latest(basepath: Path) -> str:
     latest: tuple[Version, str] | None = None
 
@@ -23,7 +34,7 @@ def get_latest(basepath: Path) -> str:
         except ValueError:
             continue
 
-        if latest is None or version > latest[0]:
+        if latest is None or _version_key(version) > _version_key(latest[0]):
             latest = (version, name)
 
     assert latest is not None
@@ -81,8 +92,8 @@ def _get_auto_version_aliases(destination: Path) -> dict[str, str]:
             version = Version.parse(name)
         except ValueError:
             continue
-        pre = int(version.prerelease) if version.prerelease else 0
-        entries[(version.major, version.minor, version.patch, pre)] = name
+        build = int(version.build) if version.build else 0
+        entries[(version.major, version.minor, version.patch, build)] = name
 
     aliases: dict[str, str] = {}
     _reduce_aliases(entries, aliases)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -94,7 +94,7 @@ async def test_not_overwrite_user_set_links_with_default(tmp_path: Path, base_co
     latest_link = tmp_path / "versions/latest"
 
     assert str(stable_link.readlink()) == "latest"
-    assert str(latest_link.readlink()) == "1.0.0-1"
+    assert str(latest_link.readlink()) == "1.0.0+1"
     assert stable_link.resolve() == latest_link.resolve()
 
     # Now we create a new build with a new version, but we set the stable link to point to the old version
@@ -111,7 +111,7 @@ async def test_not_overwrite_user_set_links_with_default(tmp_path: Path, base_co
     assert stable_link.is_symlink()
     assert latest_link.is_symlink()
     assert str(stable_link.readlink()) == "1.0.0"
-    assert str(latest_link.readlink()) == "1.0.1-1"
+    assert str(latest_link.readlink()) == "1.0.1+1"
 
 
 async def _build_wrapper(tmp_path, base_config, version="1.0.0", preamble=""):
@@ -215,7 +215,7 @@ async def test_wrapper_print_versions(tmp_path, base_config):
     lines = result.stdout.strip().splitlines()
     expected = """stable -> latest
 something -> 1.0
-latest -> 2.0.0-1
+latest -> 2.0.0+1
 2 -> 2.0
 2.0 -> 2.0.0
 1 -> 1.1
@@ -237,7 +237,7 @@ async def test_not_overwrite_user_set_version_alias_with_default(tmp_path, base_
     )
     await build_all(ctx)
 
-    assert str((tmp_path / "versions/1.0.0").readlink()) == "1.0.0-1"
+    assert str((tmp_path / "versions/1.0.0").readlink()) == "1.0.0+1"
     assert str((tmp_path / "versions/1.0").readlink()) == "1.0.0"
     assert str((tmp_path / "versions/1").readlink()) == "1.0"
 
@@ -251,7 +251,7 @@ async def test_not_overwrite_user_set_version_alias_with_default(tmp_path, base_
     )
     await build_all(ctx)
 
-    assert str((tmp_path / "versions/1.0.0").readlink()) == "1.0.0-1"
+    assert str((tmp_path / "versions/1.0.0").readlink()) == "1.0.0+1"
     assert str((tmp_path / "versions/1.0").readlink()) == "1.0.0"
     assert str((tmp_path / "versions/1.1").readlink()) == "1.0"
     assert str((tmp_path / "versions/1").readlink()) == "1.1"
@@ -314,11 +314,11 @@ def test_install_appends_build_id_when_manifest_differs(tmp_path: Path, base_con
     """Destination is append-only: build IDs may differ from staging.
 
     Scenario:
-      1. Build v1.0.0 and install → both staging and destination get 1.0.0-1
+      1. Build v1.0.0 and install → both staging and destination get 1.0.0+1
       2. Clear staging, change the build script (producing a new hash)
-      3. Rebuild → staging gets 1.0.0-1 again (it was cleared)
-      4. Install → destination already has 1.0.0-1 with a different manifest,
-         so the new build becomes 1.0.0-2
+      3. Rebuild → staging gets 1.0.0+1 again (it was cleared)
+      4. Install → destination already has 1.0.0+1 with a different manifest,
+         so the new build becomes 1.0.0+2
 
     This guarantees destination never overwrites existing builds. Build IDs
     are allowed to diverge between staging and destination, but must remain
@@ -345,8 +345,8 @@ def test_install_appends_build_id_when_manifest_differs(tmp_path: Path, base_con
     _build_envs(ctx1, ctx1.staging_paths)
     install_all(ctx1)
 
-    assert (staging / "versions/1.0.0-1").is_dir()
-    assert (destination / "versions/1.0.0-1").is_dir()
+    assert (staging / "versions/1.0.0+1").is_dir()
+    assert (destination / "versions/1.0.0+1").is_dir()
 
     shutil.rmtree(staging)
 
@@ -364,13 +364,13 @@ def test_install_appends_build_id_when_manifest_differs(tmp_path: Path, base_con
 
     _build_envs(ctx2, ctx1.staging_paths)
 
-    assert (staging / "versions/1.0.0-1").is_dir()
+    assert (staging / "versions/1.0.0+1").is_dir()
 
     install_all(ctx2)
 
-    assert (destination / "versions/1.0.0-1").is_dir()
-    assert (destination / "versions/1.0.0-2").is_dir()
+    assert (destination / "versions/1.0.0+1").is_dir()
+    assert (destination / "versions/1.0.0+2").is_dir()
 
-    manifest1 = (destination / "versions/1.0.0-1" / "manifest").read_text()
-    manifest2 = (destination / "versions/1.0.0-2" / "manifest").read_text()
+    manifest1 = (destination / "versions/1.0.0+1" / "manifest").read_text()
+    manifest2 = (destination / "versions/1.0.0+2" / "manifest").read_text()
     assert manifest1 != manifest2

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -87,11 +87,11 @@ async def test_install_idempotent(tmp_path: Path, base_config):
     )
 
     install_all(install_ctx)
-    assert (destination / "versions/1.0.0-1").is_dir()
+    assert (destination / "versions/1.0.0+1").is_dir()
 
     install_all(install_ctx)
-    assert (destination / "versions/1.0.0-1").is_dir()
-    assert not (destination / "versions/1.0.0-2").exists()
+    assert (destination / "versions/1.0.0+1").is_dir()
+    assert not (destination / "versions/1.0.0+2").exists()
 
 
 async def test_install_hello_world_example(tmp_path, monkeypatch):

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -35,33 +35,33 @@ def test_make_links_fail_missing_target(tmp_path, base_config):
 def test_make_links_on_new_package_resolves_latest(tmp_path, base_config):
     base_config["links"] = {"location": {"cool": "^"}}
 
-    (tmp_path / "location" / "1.0.0-1").mkdir(parents=True)
-    (tmp_path / "location" / "1.0.1-1").mkdir(parents=True)
+    (tmp_path / "location" / "1.0.0+1").mkdir(parents=True)
+    (tmp_path / "location" / "1.0.1+1").mkdir(parents=True)
 
     make_links(base_config["links"]["location"], destination=tmp_path / "location")
     assert os.path.islink(tmp_path / "location/cool")
     assert os.path.realpath(tmp_path / "location/cool") == str(
-        (tmp_path / "location" / "1.0.1-1")
+        (tmp_path / "location" / "1.0.1+1")
     )
 
-    (tmp_path / "location" / "1.0.2-1").mkdir(parents=True)
+    (tmp_path / "location" / "1.0.2+1").mkdir(parents=True)
     make_links(base_config["links"]["location"], destination=tmp_path / "location")
     assert os.path.realpath(tmp_path / "location/cool") == str(
-        (tmp_path / "location" / "1.0.2-1")
+        (tmp_path / "location" / "1.0.2+1")
     )
 
 
 def test_auto_version_aliases_created(tmp_path):
     destination = tmp_path / "location"
-    (destination / "1.0.0-1").mkdir(parents=True)
-    (destination / "1.1.0-1").mkdir(parents=True)
-    (destination / "1.1.1-1").mkdir(parents=True)
+    (destination / "1.0.0+1").mkdir(parents=True)
+    (destination / "1.1.0+1").mkdir(parents=True)
+    (destination / "1.1.1+1").mkdir(parents=True)
 
     make_links({}, destination=destination)
 
-    assert os.readlink(destination / "1.0.0") == "1.0.0-1"
-    assert os.readlink(destination / "1.1.0") == "1.1.0-1"
-    assert os.readlink(destination / "1.1.1") == "1.1.1-1"
+    assert os.readlink(destination / "1.0.0") == "1.0.0+1"
+    assert os.readlink(destination / "1.1.0") == "1.1.0+1"
+    assert os.readlink(destination / "1.1.1") == "1.1.1+1"
     assert os.readlink(destination / "1.0") == "1.0.0"
     assert os.readlink(destination / "1.1") == "1.1.1"
     assert os.readlink(destination / "1") == "1.1"
@@ -69,24 +69,24 @@ def test_auto_version_aliases_created(tmp_path):
 
 def test_auto_version_aliases_reflects_latest_build(tmp_path):
     destination = tmp_path / "location"
-    (destination / "1.0.0-1").mkdir(parents=True)
-    (destination / "1.0.0-2").mkdir(parents=True)
-    (destination / "1.0.1-1").mkdir(parents=True)
-    (destination / "1.0.1-2").mkdir(parents=True)
+    (destination / "1.0.0+1").mkdir(parents=True)
+    (destination / "1.0.0+2").mkdir(parents=True)
+    (destination / "1.0.1+1").mkdir(parents=True)
+    (destination / "1.0.1+2").mkdir(parents=True)
 
     make_links({}, destination=destination)
 
-    assert os.readlink(destination / "1.0.0") == "1.0.0-2"
-    assert os.readlink(destination / "1.0.1") == "1.0.1-2"
+    assert os.readlink(destination / "1.0.0") == "1.0.0+2"
+    assert os.readlink(destination / "1.0.1") == "1.0.1+2"
     assert os.readlink(destination / "1.0") == "1.0.1"
     assert os.readlink(destination / "1") == "1.0"
 
 
 def test_auto_version_aliases_user_override(tmp_path):
     destination = tmp_path / "location"
-    (destination / "1.0.0-1").mkdir(parents=True)
-    (destination / "1.1.0-1").mkdir(parents=True)
-    (destination / "1.1.1-1").mkdir(parents=True)
+    (destination / "1.0.0+1").mkdir(parents=True)
+    (destination / "1.1.0+1").mkdir(parents=True)
+    (destination / "1.1.1+1").mkdir(parents=True)
 
     make_links({"1.1": "1.1.0"}, destination=destination)
 
@@ -96,9 +96,9 @@ def test_auto_version_aliases_user_override(tmp_path):
 
 def test_auto_version_aliases_multiple_majors(tmp_path):
     destination = tmp_path / "location"
-    (destination / "1.0.0-1").mkdir(parents=True)
-    (destination / "2.0.0-1").mkdir(parents=True)
-    (destination / "2.1.0-1").mkdir(parents=True)
+    (destination / "1.0.0+1").mkdir(parents=True)
+    (destination / "2.0.0+1").mkdir(parents=True)
+    (destination / "2.1.0+1").mkdir(parents=True)
 
     make_links({}, destination=destination)
 


### PR DESCRIPTION
Instead of having versions like 1.0.0-1, we use 1.0.0+1. The - is
reserved for pre-release information according to semver.
