### PR TITLE
Extract sync to stand alone config

### DIFF
--- a/src/karsk/commands/_common.py
+++ b/src/karsk/commands/_common.py
@@ -7,6 +7,7 @@ from karsk.engine import CpuArchNameNative, EngineNameNative
 
 
 argument_config_file = click.argument("config-file", type=Path)
+argument_areas_file = click.argument("areas-file", type=Path)
 option_arch = click.option(
     "--arch",
     type=click.Choice(get_args(CpuArchNameNative)),

--- a/src/karsk/commands/sync.py
+++ b/src/karsk/commands/sync.py
@@ -10,8 +10,12 @@ from pathlib import Path
 
 import click
 
-from karsk.commands._common import argument_config_file, option_staging
-from karsk.config import AreaConfig
+from karsk.commands._common import (
+    argument_areas_file,
+    argument_config_file,
+    option_staging,
+)
+from karsk.config import AreaConfig, load_areas
 from karsk.context import Context
 from karsk.paths import Paths
 from karsk.utils import redirect_output
@@ -169,28 +173,30 @@ class Sync:
 
 async def sync_all(
     ctx: Context,
+    areas: list[AreaConfig],
     no_async: bool,
     dry_run: bool,
 ) -> None:
     syncer = Sync(ctx, dry_run=dry_run)
 
     if no_async:
-        for area in ctx.config.areas:
+        for area in areas:
             await syncer.sync_to(area)
         return
 
     results = await asyncio.gather(
-        *(syncer.sync_to(area) for area in ctx.config.areas), return_exceptions=True
+        *(syncer.sync_to(area) for area in areas), return_exceptions=True
     )
     for index, result in enumerate(results):
         if not isinstance(result, BaseException):
             continue
-        print(f"During syncing to {ctx.config.areas[index].name}:")
+        print(f"During syncing to {areas[index].name}:")
         raise result
 
 
 @click.command("sync", help="Synchronise all locations")
 @argument_config_file
+@argument_areas_file
 @option_staging
 @click.option(
     "--no-async",
@@ -204,12 +210,14 @@ async def sync_all(
     default=False,
 )
 def subcommand_sync(
-    config_file: Path, staging: Path, no_async: bool, dry_run: bool
+    config_file: Path, areas_file: Path, staging: Path, no_async: bool, dry_run: bool
 ) -> None:
     ctx = Context.from_config_file(config_file, staging=staging, engine="native")
+    areas = load_areas(areas_file)
     asyncio.run(
         sync_all(
             ctx,
+            areas=areas,
             no_async=no_async,
             dry_run=dry_run,
         )

--- a/src/karsk/config.py
+++ b/src/karsk/config.py
@@ -37,9 +37,6 @@ class Config(BaseModel):
     )
 
     packages: list[PackageConfig] = Field(description="List of packages to build")
-    areas: list[AreaConfig] = Field(
-        default_factory=list, description="Areas to sync build artifacts to"
-    )
     links: dict[str, str] = Field(
         default_factory=dict, description="Symbolic links setup"
     )
@@ -128,8 +125,6 @@ class FileConfig(BaseModel):
 
 
 class AreaConfig(BaseModel):
-    """TODO: AreaConfig"""
-
     name: str = Field(description="Display name")
     host: str = Field(description="Hostname or IP-address")
 
@@ -139,3 +134,9 @@ def load_config(path: Path) -> Config:
         return Config.model_validate(
             yaml.safe_load(f.read()), context={"cwd": path.absolute().parent}
         )
+
+
+def load_areas(path: Path) -> list[AreaConfig]:
+    with open(path) as f:
+        data = yaml.safe_load(f.read())
+    return [AreaConfig.model_validate(item) for item in data["areas"]]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,11 +91,27 @@ def test_build_accepts_args(mock_build, runner, config_file):
     mock_build.assert_called_once()
 
 
+@pytest.fixture
+def areas_file(tmp_path):
+    path = tmp_path / "areas.yaml"
+    path.write_text(
+        yaml.dump({"areas": [{"name": "destination", "host": "example.com"}]})
+    )
+    return path
+
+
 @patch("karsk.commands.sync.sync_all", new_callable=AsyncMock)
-def test_sync_accepts_args(mock_sync, runner, config_file):
+def test_sync_accepts_args(mock_sync, runner, config_file, areas_file):
     result = runner.invoke(
         cli,
-        ["sync", str(config_file), "--staging", str(config_file.parent), "--dry-run"],
+        [
+            "sync",
+            str(config_file),
+            str(areas_file),
+            "--staging",
+            str(config_file.parent),
+            "--dry-run",
+        ],
     )
     assert result.exit_code == 0, result.output
     mock_sync.assert_called_once()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3,7 +3,7 @@ from subprocess import CalledProcessError
 from karsk.builder import build_all
 import pytest
 
-from karsk.config import Config
+from karsk.config import AreaConfig, Config
 from karsk.commands.sync import Sync, sync_all
 from karsk.context import Context
 
@@ -43,11 +43,15 @@ def base_config():
                 "build": BUILD_SCRIPT,
             },
         ],
-        "areas": [{"name": "destination", "host": "example.com"}],
     }
 
     config = Config.model_validate(config, context={"cwd": os.path.dirname(__file__)})
     return config
+
+
+@pytest.fixture
+def areas():
+    return [AreaConfig(name="destination", host="example.com")]
 
 
 async def _deploy_config(config, tmp_path):
@@ -57,7 +61,7 @@ async def _deploy_config(config, tmp_path):
     return context
 
 
-async def test_successful_sync(tmp_path, base_config):
+async def test_successful_sync(tmp_path, base_config, areas):
     ctx = await _deploy_config(base_config, tmp_path)
 
     installed_file_path = ctx.out("A") / "bin/a_file"
@@ -65,6 +69,7 @@ async def test_successful_sync(tmp_path, base_config):
 
     await sync_all(
         ctx,
+        areas=areas,
         no_async=False,
         dry_run=False,
     )
@@ -72,19 +77,20 @@ async def test_successful_sync(tmp_path, base_config):
     assert installed_file_path.exists()
 
 
-async def test_failing_sync(tmp_path, base_config, monkeypatch):
+async def test_failing_sync(tmp_path, base_config, areas, monkeypatch):
     """Try to sync with a broken RSH to simulate unreachable host"""
     ctx = await _deploy_config(base_config, tmp_path)
     monkeypatch.setattr(Sync, "RSH", ["sh", "-c", "exit 1"])
     with pytest.raises(CalledProcessError):
         await sync_all(
             ctx,
+            areas=areas,
             no_async=False,
             dry_run=False,
         )
 
 
-async def test_sync_with_non_local_prefix(tmp_path, base_config):
+async def test_sync_with_non_local_prefix(tmp_path, base_config, areas):
     from karsk.builder import _build_envs
 
     base_config.destination = tmp_path
@@ -100,6 +106,7 @@ async def test_sync_with_non_local_prefix(tmp_path, base_config):
 
     await sync_all(
         ctx,
+        areas=areas,
         no_async=False,
         dry_run=False,
     )


### PR DESCRIPTION
It doesn't really make sense to have the areas config be part of the
building configuration. Let's make that an individual configuration file
instead.

solves: https://github.com/equinor/karsk/issues/140