### PR TITLE
Use temporary build directory instead of out

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1,14 +1,18 @@
 {
-  ...
-}:
-
-{
   languages.python = {
     enable = true;
-    uv.enable = true;
-    uv.sync.enable = true;
     venv.enable = true;
+
+    uv = {
+      enable = true;
+      sync = {
+        enable = true;
+        allExtras = true;
+      };
+    };
   };
+
+  languages.rust.enable = true;
 
   # Use system git rather than Nix' because of code signing shenanigans on macOS
   env.KARSK_GIT = "/usr/bin/git";

--- a/src/karsk/builder.py
+++ b/src/karsk/builder.py
@@ -90,15 +90,23 @@ async def _async_build(
 
 async def _build(ctx: Context, pkg: Package, tmp: str) -> None:
     out = ctx.staging_paths.out(pkg)
-    src = ctx.staging_paths.src(pkg)
-    try:
-        out.mkdir()
-    except FileExistsError:
-        print(
+    if out.is_dir():
+        console.log(
             f"Ignoring {pkg.fullname}: Already built at {out}",
-            file=sys.stderr,
         )
         return
+
+    if ctx.engine.name == "native":
+        # We use the target path in native mode. If an error occurs during
+        # building, the bad build will stay and will result in a bad
+        # installation. This is OK because 'native' is only used in tests.
+        tmp_out = ctx.staging_paths.out(pkg)
+    else:
+        tmp_out = ctx.staging_paths.builds / pkg.config.name
+    shutil.rmtree(tmp_out, ignore_errors=True)
+    tmp_out.mkdir(parents=True, exist_ok=False)
+
+    src = ctx.staging_paths.src(pkg)
 
     print(f"Building {pkg.fullname}...")
     try:
@@ -106,34 +114,25 @@ async def _build(ctx: Context, pkg: Package, tmp: str) -> None:
     except (Exception, KeyboardInterrupt):
         if src is not None:
             shutil.rmtree(src)
-        shutil.rmtree(out)
         raise
 
-    env, volumes, cwd = _prepare_build_env(ctx, pkg, src, out, tmp)
+    env, volumes, cwd = _prepare_build_env(ctx, pkg, src, tmp_out, tmp)
 
-    with open(out / "build.log", "w") as buildlog:
+    with open(tmp_out / "build.log", "w") as buildlog:
         print("Built with https://github.com/equinor/karsk", file=buildlog)
         print(f"Build date: {datetime.now()}", file=buildlog)
         print("----- BUILD CONFIG -----", file=buildlog)
         print(pkg.config.model_dump_json(), file=buildlog)
         print("------ BUILD  LOG ------", file=buildlog)
 
-        if not await _async_build(ctx, pkg, env, buildlog, volumes, cwd):
-            for i in range(1000):
-                fail_path = ctx.staging_paths.store / f"fail-{pkg.fullname}-{i}"
-                if not fail_path.exists():
-                    break
-            else:
-                sys.exit(f"Could not move failed build at {out}")
-
-            out.rename(fail_path)
-            sys.exit(
-                f"Building {pkg.fullname} failed. Inspect the build at: {fail_path}"
-            )
+        if await _async_build(ctx, pkg, env, buildlog, volumes, cwd):
+            shutil.move(tmp_out, out)
+        else:
+            sys.exit(f"Building {pkg.fullname} failed. Inspect the build at: {tmp_out}")
 
 
 def _prepare_build_env(
-    ctx: Context, pkg: Package, src: Path | None, out: Path, tmp: str
+    ctx: Context, pkg: Package, src: Path | None, tmp_out: Path, tmp: str
 ) -> tuple[dict[str, str], list[VolumeBind], Path]:
     env = {
         **{x.config.name: str(ctx.target_paths.out(x)) for x in pkg.depends},
@@ -163,7 +162,7 @@ def _prepare_build_env(
     elif src is not None and ctx.engine.name != "native":
         volumes.append((src, f"/tmp/pkgsrc/{src.name}", "ro"))
 
-    volumes.append((out, ctx.target_paths.out(pkg), "rw"))
+    volumes.append((tmp_out, ctx.target_paths.out(pkg), "rw"))
 
     return env, volumes, cwd
 

--- a/src/karsk/paths.py
+++ b/src/karsk/paths.py
@@ -16,9 +16,13 @@ class Paths:
 
     @property
     def cache(self) -> Path:
-        if not self._is_staging:
-            raise RuntimeError("Cache path only exists in staging")
+        self._assert_not_staging("Cache path")
         return self._base / "cache"
+
+    @property
+    def builds(self) -> Path:
+        self._assert_not_staging("Builds path")
+        return self._base / "builds"
 
     def out(self, pkg: Package) -> Path:
         return self.store / pkg.out_relpath
@@ -27,3 +31,7 @@ class Paths:
         if (p := pkg.src_relpath) is None:
             return None
         return self.cache / p
+
+    def _assert_not_staging(self, name: str) -> None:
+        if not self._is_staging:
+            raise RuntimeError(f"{name} only exists in staging")


### PR DESCRIPTION
Instead of building things inside of the out directory and then renaming it if something goes wrong, we instead build in a temporary build directory and rename to the out directory when something goes right.