### PR TITLE
Disable security opt for image build

### DIFF
--- a/src/karsk/engine.py
+++ b/src/karsk/engine.py
@@ -95,6 +95,10 @@ class _Engine:
         if await self._has_image(image_name):
             return image_name
 
+        build_extra_args: list[str] = []
+        if self.name == "podman":
+            build_extra_args.extend(["--security-opt", "label=disable"])
+
         proc = await asyncio.create_subprocess_exec(
             self.name,
             "build",
@@ -106,6 +110,7 @@ class _Engine:
             image_name,
             "--label",
             "karsk",
+            *build_extra_args,
             image.parent,
         )
         if await proc.wait() != os.EX_OK:


### PR DESCRIPTION
We already do this for run, we also facilitate it for building images.

SELinux on RHEL/Rocky has a policy called deny_execmem. Some libraries, like glibc and ncurses write or execute memory during their library reloading/relocation phase at update time.

Hence for instance running dnf update will fail (unless there is a specific SELinux policy in place)
