### PR TITLE
Use absolute paths for staging directory

### DIFF
--- a/src/karsk/paths.py
+++ b/src/karsk/paths.py
@@ -14,7 +14,7 @@ class Paths:
     ) -> None:
         base = base.absolute()
         self._base = base
-        self._cache = cache
+        self._cache = cache.absolute() if cache is not None else None
         self._is_staging = is_staging
 
         self.bin = base / "bin"


### PR DESCRIPTION
Karsk build will fail when trying to create the volume mounts with the
following error:

petsc> Error: creating named volume
"staging/cache/petsc-a093114c2e7b4ba1f47e6ac8a72c57724150f16d.git":
running volume create option: names must match
[a-zA-Z0-9][a-zA-Z0-9_.-]*: invalid argument

The tests does not capture this as they are all running native.

The hello world does not capture it as it must be done with a git as src
